### PR TITLE
Update .dockerignore to exclude additional log, test, and configuration files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,19 +1,18 @@
 # Node modules (will be installed inside container)
 node_modules/
+npm-debug.log
+yarn-debug.log
+yarn-error.log
 
-# Git files
+# Version control
 .git/
+.github/
 .gitignore
 
 # Environment variables and secrets
 .env
 .env.*
 !.env.example
-
-# Development files
-npm-debug.log
-yarn-debug.log
-yarn-error.log
 
 # OS files
 .DS_Store
@@ -22,6 +21,11 @@ Thumbs.db
 # Docker files (to prevent recursive copying)
 Dockerfile
 docker-compose*.yml
+.dockerignore
+
+# Deployment configurations
+k8s/
+vercel.json
 
 # Logs
 logs/
@@ -29,7 +33,17 @@ logs/
 
 # Test files
 __tests__/
+test/
+tests/
 coverage/
+.nyc_output/
 
 # Documentation
-README.md
+*.md
+LICENSE
+docs/
+
+# Development configuration
+.vscode/
+.idea/
+.editorconfig


### PR DESCRIPTION
This pull request includes several updates to the `.dockerignore` file to improve the efficiency of Docker builds by excluding unnecessary files and directories.

### Improvements to `.dockerignore`:

* Added log files to be ignored: `npm-debug.log`, `yarn-debug.log`, and `yarn-error.log`.
* Updated version control section to ignore `.github/` directory.
* Added deployment configurations to be ignored: `k8s/` and `vercel.json`.
* Expanded test files to be ignored: `test/`, `tests/`, and `.nyc_output/`.
* Added development configuration files to be ignored: `.vscode/`, `.idea/`, and `.editorconfig`.