### PR TITLE
Added K8S Config

### DIFF
--- a/k8s/blue-deployment.yaml
+++ b/k8s/blue-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: email-verifier-blue
+  namespace: email-verifier
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: email-verifier
+      version: blue
+  template:
+    metadata:
+      labels:
+        app: email-verifier
+        version: blue
+    spec:
+      containers:
+      - name: email-verifier
+        image: tauqeerops/email-verifier:latest

--- a/k8s/blue-service.yaml
+++ b/k8s/blue-service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: email-verifier-blue
-  namespace: email-verifier
+  name: email-verifier-blue-svc
 spec:
+  type: ClusterIP
   selector:
     app: email-verifier
     version: blue
   ports:
-  - port: 3000
-    targetPort: 3000
-  type: ClusterIP 
+    - protocol: TCP
+      port: 80
+      targetPort: 3000

--- a/k8s/blue-service.yaml
+++ b/k8s/blue-service.yaml
@@ -3,15 +3,11 @@ kind: Service
 metadata:
   name: email-verifier-blue
   namespace: email-verifier
-  annotations:
-    service.beta.kubernetes.io/azure-load-balancer-internal: "false"
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /health
 spec:
   selector:
     app: email-verifier
     version: blue
   ports:
-  - port: 80
+  - port: 3000
     targetPort: 3000
-  type: LoadBalancer
-  sessionAffinity: None
+  type: ClusterIP 

--- a/k8s/blue-service.yaml
+++ b/k8s/blue-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: email-verifier-blue
+  namespace: email-verifier
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "false"
+    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /health
+spec:
+  selector:
+    app: email-verifier
+    version: blue
+  ports:
+  - port: 80
+    targetPort: 3000
+  type: LoadBalancer
+  sessionAffinity: None

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -4,5 +4,5 @@ metadata:
   name: email-verifier-config
   namespace: email-verifier
 data:
-  PORT: 3000
+  PORT: "3000"
   NODE_ENV: "production"

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: email-verifier-config
+  namespace: email-verifier
+data:
+  PORT: 3000
+  NODE_ENV: "production"

--- a/k8s/green-deployment.yaml
+++ b/k8s/green-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: email-verifier-green
+  namespace: email-verifier
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: email-verifier
+      version: green
+  template:
+    metadata:
+      labels:
+        app: email-verifier
+        version: green
+    spec:
+      containers:
+      - name: email-verifier
+        image: tauqeerops/email-verifier:modern-ui # Update to the new version

--- a/k8s/green-service.yaml
+++ b/k8s/green-service.yaml
@@ -3,15 +3,11 @@ kind: Service
 metadata:
   name: email-verifier-green
   namespace: email-verifier
-  annotations:
-    service.beta.kubernetes.io/azure-load-balancer-internal: "false"
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /health
 spec:
   selector:
     app: email-verifier
     version: green
   ports:
-  - port: 80
+  - port: 3000
     targetPort: 3000
-  type: LoadBalancer
-  sessionAffinity: None
+  type: ClusterIP 

--- a/k8s/green-service.yaml
+++ b/k8s/green-service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: email-verifier-green
-  namespace: email-verifier
+  name: email-verifier-green-svc
 spec:
+  type: ClusterIP
   selector:
     app: email-verifier
     version: green
   ports:
-  - port: 3000
-    targetPort: 3000
-  type: ClusterIP 
+    - protocol: TCP
+      port: 80
+      targetPort: 3000

--- a/k8s/green-service.yaml
+++ b/k8s/green-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: email-verifier-green
+  namespace: email-verifier
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "false"
+    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /health
+spec:
+  selector:
+    app: email-verifier
+    version: green
+  ports:
+  - port: 80
+    targetPort: 3000
+  type: LoadBalancer
+  sessionAffinity: None

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,25 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: email-verifier
+  namespace: email-verifier
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: email-verifier
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -4,13 +4,11 @@ metadata:
   name: email-verifier
   namespace: email-verifier
   annotations:
-    kubernetes.io/ingress.class: "azure/application-gateway"
-    appgw.ingress.kubernetes.io/ssl-redirect: "true"
-    appgw.ingress.kubernetes.io/rewrite-url: "/"
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
-  tls:
-  - hosts:
-    - true-mail.com
+  ingressClassName: nginx
   rules:
   - host: true-mail.com
     http:
@@ -21,18 +19,18 @@ spec:
           service:
             name: email-verifier-blue
             port:
-              number: 80
+              number: 3000
       - path: /green
         pathType: Prefix
         backend:
           service:
             name: email-verifier-green
             port:
-              number: 80
+              number: 3000
       - path: /
         pathType: Prefix
         backend:
           service:
             name: email-verifier-blue  # Default route
             port:
-              number: 80
+              number: 3000

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,36 +1,37 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: email-verifier
-  namespace: email-verifier
+  name: email-verifier-ingress
   annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
   ingressClassName: nginx
   rules:
-  - host: true-mail.com
-    http:
-      paths:
-      - path: /blue
-        pathType: Prefix
-        backend:
-          service:
-            name: email-verifier-blue
-            port:
-              number: 3000
-      - path: /green
-        pathType: Prefix
-        backend:
-          service:
-            name: email-verifier-green
-            port:
-              number: 3000
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: email-verifier-blue  # Default route
-            port:
-              number: 3000
+    - http:
+        paths:
+          - path: /green(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: email-verifier-green-svc
+                port:
+                  number: 3000
+          - path: /blue(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: email-verifier-blue-svc
+                port:
+                  number: 3000
+          - path: /(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: email-verifier-blue-svc
+                port:
+                  number: 3000

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: email-verifier
+  namespace: email-verifier
+  annotations:
+    kubernetes.io/ingress.class: "azure/application-gateway"
+    appgw.ingress.kubernetes.io/ssl-redirect: "true"
+    appgw.ingress.kubernetes.io/rewrite-url: "/"
+spec:
+  tls:
+  - hosts:
+    - true-mail.com
+  rules:
+  - host: true-mail.com
+    http:
+      paths:
+      - path: /blue
+        pathType: Prefix
+        backend:
+          service:
+            name: email-verifier-blue
+            port:
+              number: 80
+      - path: /green
+        pathType: Prefix
+        backend:
+          service:
+            name: email-verifier-green
+            port:
+              number: 80
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: email-verifier-blue  # Default route
+            port:
+              number: 80

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: email-verifier

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: email-verifier
 type: Opaque
 data:
-  API_KEY: YmI1OTRhMjBkMmI3ZDg5OTU2MTI2NTYwNWQ1YjVmZGVkYWU5M2E2OQ==
+  EMAIL_API_KEY: YmI1OTRhMjBkMmI3ZDg5OTU2MTI2NTYwNWQ1YjVmZGVkYWU5M2E2OQ==

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: email-verifier-secrets
+  namespace: email-verifier
+type: Opaque
+data:
+  API_KEY: YmI1OTRhMjBkMmI3ZDg5OTU2MTI2NTYwNWQ1YjVmZGVkYWU5M2E2OQ==


### PR DESCRIPTION
This pull request includes several changes to the Kubernetes configuration files for the email verifier service. The changes introduce new deployments, services, a config map, a horizontal pod autoscaler, ingress rules, a namespace, and a secret. The most important changes are summarized below:

### New Deployments and Services:
* Added `blue` deployment and service for the email verifier application, specifying 3 replicas and using the latest image version. (`k8s/blue-deployment.yaml`, `k8s/blue-service.yaml`) [[1]](diffhunk://#diff-e4eb490ce7d1512cb208d7decfc8c99cb9b727ee9914f6b8ebc19c7f11648537R1-R20) [[2]](diffhunk://#diff-f4198575b23eaea1d251af235d635451ac7684177c62e9e1b4d1dcdac0747025R1-R13)
* Added `green` deployment and service for the email verifier application, specifying 3 replicas and using the modern UI image version. (`k8s/green-deployment.yaml`, `k8s/green-service.yaml`) [[1]](diffhunk://#diff-bb30563c4d3341d87a0437ed8dc4ca64b84cc8f32bc5211f8aabb73d3160fbd1R1-R20) [[2]](diffhunk://#diff-f37843e27c4a8e1bc5e5d1b4cf9b5d43f7d8fb28957b1d083efb84531bd4e8fdR1-R13)

### Configuration Management:
* Added a config map for the email verifier application with environment variables for port and node environment. (`k8s/configmap.yaml`)
* Added a secret for the email verifier application containing an encoded email API key. (`k8s/secret.yaml`)

### Autoscaling and Ingress:
* Added a horizontal pod autoscaler for the email verifier application to scale between 2 and 10 replicas based on CPU and memory utilization. (`k8s/hpa.yaml`)
* Added ingress rules to route traffic to the `blue` and `green` services based on URL paths, with CORS and SSL configurations. (`k8s/ingress.yaml`)

### Namespace:
* Added a namespace for the email verifier application to isolate its resources. (`k8s/namespace.yaml`)